### PR TITLE
Switch Flask app to port 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ COPY scripts/ /app/scripts/
 # Tornar os scripts executáveis
 RUN chmod +x /app/scripts/*.sh
 
-# Expor a porta 5000 (ou a porta em que seu Flask está rodando)
-EXPOSE 4999
+# Expor a porta 80 em que o Flask será executado
+EXPOSE 80
 
 # Script de entrada que inicia o PostgreSQL e depois a aplicação
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -532,18 +532,18 @@ def homepage():
 
 def open_urls():
     urls_old = [
-        'http://127.0.0.1:4999/maquinas',
-        'http://127.0.0.1:4999/posicoes',
-        'http://127.0.0.1:4999/sensores',
-        'http://127.0.0.1:4999/status',
-        'http://127.0.0.1:4999/calibrations',
-        'http://127.0.0.1:4999/view_h',
-        'http://127.0.0.1:4999/view',
-        'http://127.0.0.1:4999/limits_'
+        'http://127.0.0.1/maquinas',
+        'http://127.0.0.1/posicoes',
+        'http://127.0.0.1/sensores',
+        'http://127.0.0.1/status',
+        'http://127.0.0.1/calibrations',
+        'http://127.0.0.1/view_h',
+        'http://127.0.0.1/view',
+        'http://127.0.0.1/limits_'
     ]
 
     urls = [
-        'http://127.0.0.1:4999/'
+        'http://127.0.0.1/'
     ]
 
     for url in urls:
@@ -559,5 +559,4 @@ if __name__ == '__main__':
     start_measurement_threads()
 
     # Run the app
-    app.run(debug=False, host='0.0.0.0', port=4999)
-    #app.run(debug=False, port=4999)
+    app.run(debug=False, host='0.0.0.0', port=80)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker build -t meva .
 E para executar:
 
 ```
-docker run -p 4999:4999 meva
+docker run -p 80:80 meva
 ```
 
 O container inicia o PostgreSQL, cria o banco `BD_MEP` com as tabelas definidas em

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   web:
     build: .
     ports:
-      - "4999:4999"
+      - "80:80"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- expose port 80 in the Dockerfile
- map to port 80 in docker-compose
- update MEVA.py to run on port 80 and update URLs
- adjust README instructions

## Testing
- `python -m py_compile MEVA/MEVA.py`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504c26c0d8833197581a8a4be146eb