### PR TITLE
Add sensor debug page

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -515,6 +515,22 @@ def limits_():
     return render_template('limits.html', machine_limits=machine_limits)
 
 
+@app.route('/debug')
+def debug_page():
+    sensors = queries.get_sensors()
+    return render_template('debug.html', sensors=sensors)
+
+
+@app.route('/sensor_reading/<int:sensor_id>')
+def sensor_reading(sensor_id):
+    sensor = queries.get_sensor(sensor_id)
+    value = None
+    if sensor:
+        ip = sensor[1]
+        value = fast_get_distance(ip, 8899)
+    return jsonify({'value': value})
+
+
 @app.route('/set_limits/<machine_id>/<float:limit>')
 def set_limits(machine_id, limit):
     limit_data = limits.load_limits()

--- a/MEVA/queries.py
+++ b/MEVA/queries.py
@@ -114,6 +114,14 @@ def get_sensors():
     conn.close()
     return sensors
 
+def get_sensor(sensor_id):
+    conn = connect()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM Sensores WHERE ID = %s;", (sensor_id,))
+    sensor = cur.fetchone()
+    conn.close()
+    return sensor
+
 def get_sensor_pairs():
     conn = connect()
     cur = conn.cursor()

--- a/MEVA/templates/debug.html
+++ b/MEVA/templates/debug.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <title>Debug Sensor</title>
+</head>
+<body>
+    <h1>Debug de Sensor</h1>
+    <label for="sensor">Selecione o sensor:</label>
+    <select id="sensor">
+        <option value="">-- Selecione --</option>
+        {% for sensor in sensors %}
+        <option value="{{ sensor[0] }}">{{ sensor[0] }} - {{ sensor[1] }}</option>
+        {% endfor %}
+    </select>
+    <p>Leitura Atual: <span id="reading">--</span></p>
+
+    <script>
+        const select = document.getElementById('sensor');
+        const reading = document.getElementById('reading');
+        let current = null;
+        select.addEventListener('change', () => {
+            current = select.value;
+            reading.textContent = '--';
+        });
+        setInterval(() => {
+            if (!current) return;
+            fetch(`/sensor_reading/${current}`)
+                .then(r => r.json())
+                .then(data => {
+                    if (data.value === null) {
+                        reading.textContent = 'Erro';
+                    } else {
+                        reading.textContent = data.value.toFixed(2) + ' mm';
+                    }
+                })
+                .catch(() => reading.textContent = 'Erro');
+        }, 1000);
+    </script>
+</body>
+</html>

--- a/MEVA/templates/homepage.html
+++ b/MEVA/templates/homepage.html
@@ -89,6 +89,11 @@
             <a href="/view">Ir para Monitoramento</a>
         </div>
         <div class="card">
+            <div class="icon">&#9881;</div>
+            <div class="card-title">Debug</div>
+            <a href="/debug">Ir para Debug</a>
+        </div>
+        <div class="card">
             <div class="icon">&#10132;</div>
             <div class="card-title">Limites</div>
             <a href="/limits_">Ir para Limites</a>


### PR DESCRIPTION
## Summary
- allow selecting sensors in a new debug route
- add endpoint to poll raw distance values
- expose helper `get_sensor` query
- link to the debug page from the homepage

## Testing
- `python -m py_compile MEVA/MEVA.py MEVA/queries.py`

------
https://chatgpt.com/codex/tasks/task_e_6850649a9c248331a2675e999ceb6dc4