### PR TITLE
Add DB status section in debug page

### DIFF
--- a/MEVA/templates/debug.html
+++ b/MEVA/templates/debug.html
@@ -18,6 +18,25 @@
     </select>
     <p>Leitura Atual: <span id="reading">--</span></p>
 
+    <h2>Status do Banco de Dados</h2>
+    {% if connection_status %}
+        <p class="connected">Conectado com sucesso.</p>
+        <table>
+            <tr>
+                <th>Tabela</th>
+                <th>Linhas</th>
+            </tr>
+            {% for table, count in table_counts.items() %}
+            <tr>
+                <td>{{ table }}</td>
+                <td>{{ count }}</td>
+            </tr>
+            {% endfor %}
+        </table>
+    {% else %}
+        <p class="disconnected">Falha ao conectar ao banco de dados.</p>
+    {% endif %}
+
     <script>
         const select = document.getElementById('sensor');
         const reading = document.getElementById('reading');


### PR DESCRIPTION
## Summary
- show DB connection status and table row counts on the debug screen

## Testing
- `python3 -m py_compile MEVA/MEVA.py MEVA/queries.py MEVA/database.py MEVA/get_distance.py MEVA/fast_get_distance.py MEVA/fake_sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_685165105aa48331b59cb1db761d6e4f