### PR TITLE
Fix Postgres version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Instalar dependências do sistema
 RUN apt-get update && apt-get install -y \
-    libpq-dev gcc postgresql postgresql-contrib \
+    libpq-dev gcc postgresql-13 postgresql-contrib-13 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copiar arquivo de requisitos e instalar dependências Python

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Para construir a imagem:
 docker build -t meva .
 ```
 
+A imagem fixa o PostgreSQL 13 para garantir consistência do caminho de dados.
+
 E para executar:
 
 ```


### PR DESCRIPTION
## Summary
- pin Postgres version in Dockerfile to 13
- document the Postgres version in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516738b524833193aa3f365f85c072