### PR TITLE
Prevent browser launch in production

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -3,6 +3,7 @@ import psycopg2
 from psycopg2 import sql
 import config
 import webbrowser
+import os
 from time import sleep
 import threading
 import time
@@ -608,8 +609,9 @@ def open_urls():
 
 
 if __name__ == '__main__':
-    # Start the URLs opening in a separate thread
-    threading.Thread(target=open_urls).start()
+    # Optionally open the web interface when running locally
+    if os.environ.get('OPEN_BROWSER_ON_STARTUP') == '1':
+        threading.Thread(target=open_urls).start()
 
     # Start the measurement threads (if needed)
     start_measurement_threads()


### PR DESCRIPTION
## Summary
- add `os` import to support environment checks
- gate optional browser launch behind `OPEN_BROWSER_ON_STARTUP`

## Testing
- `python3 -m py_compile MEVA/MEVA.py`


------
https://chatgpt.com/codex/tasks/task_e_68516f119b688331ac18c2b7c0b0a2bb