### PR TITLE
Initialize Postgres cluster when empty

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# initialize data directory if empty
+if [ ! -s /var/lib/postgresql/13/main/PG_VERSION ]; then
+    su postgres -c "/usr/lib/postgresql/13/bin/initdb -D /var/lib/postgresql/13/main"
+fi
+
 service postgresql start
 
 # ensure postgres is ready


### PR DESCRIPTION
## Summary
- ensure PostgreSQL cluster is initialized if the data directory is empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68516f51b17083319fe2b226c7252b36