### PR TITLE
Update README with persistent volume info

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,27 @@ docker build -t meva .
 ```
 
 A imagem fixa o PostgreSQL 13 para garantir consistência do caminho de dados.
+O diretório de dados utilizado pela imagem única é `/var/lib/postgresql/13/main`.
+No `docker-compose.yml` usa-se a imagem oficial do Postgres, cujo volume padrão é
+`/var/lib/postgresql/data`.
 
 E para executar:
 
 ```
 docker run -p 80:80 meva
 ```
+
+Se desejar persistir os dados localmente, mapeie um volume para o diretório de
+dados do container:
+
+```
+docker run -p 80:80 \
+  -v $(pwd)/pgdata:/var/lib/postgresql/13/main \
+  meva
+```
+
+O entrypoint do container inicializa esse diretório automaticamente caso ele
+esteja vazio.
 
 O container inicia o PostgreSQL, cria o banco `BD_MEP` com as tabelas definidas em
 `scripts/create_tables.sql` e em seguida executa a aplicação Flask.


### PR DESCRIPTION
## Summary
- mention the data directory used by the single-container image
- describe the path used in the `docker-compose.yml`
- show how to run the container with a volume and highlight auto initialization

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68516f56a0c08331b2f93ae4c9c6f374