### PR TITLE
Remove Postgres 13 lock and unify data path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Instalar dependências do sistema
 RUN apt-get update && apt-get install -y \
-    libpq-dev gcc postgresql-13 postgresql-contrib-13 \
+    libpq-dev gcc postgresql postgresql-contrib \
     && rm -rf /var/lib/apt/lists/*
 
 # Copiar arquivo de requisitos e instalar dependências Python

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Para construir a imagem:
 docker build -t meva .
 ```
 
-A imagem fixa o PostgreSQL 13 para garantir consistência do caminho de dados.
-O diretório de dados utilizado pela imagem única é `/var/lib/postgresql/13/main`.
-No `docker-compose.yml` usa-se a imagem oficial do Postgres, cujo volume padrão é
-`/var/lib/postgresql/data`.
+A imagem instala o PostgreSQL disponível na distribuição.
+O diretório de dados utilizado pela imagem única é `/var/lib/postgresql/data`.
+No `docker-compose.yml` usa-se a imagem oficial do Postgres, cujo volume padrão
+também é `/var/lib/postgresql/data`.
 
 E para executar:
 
@@ -27,7 +27,7 @@ dados do container:
 
 ```
 docker run -p 80:80 \
-  -v $(pwd)/pgdata:/var/lib/postgresql/13/main \
+  -v $(pwd)/pgdata:/var/lib/postgresql/data \
   meva
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   db:
-    image: postgres:13
+    image: postgres
     environment:
       POSTGRES_DB: BD_MEP
       POSTGRES_USER: postgres

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 set -e
 
+PGDATA=/var/lib/postgresql/data
+
 # initialize data directory if empty
-if [ ! -s /var/lib/postgresql/13/main/PG_VERSION ]; then
-    su postgres -c "/usr/lib/postgresql/13/bin/initdb -D /var/lib/postgresql/13/main"
+if [ ! -s "$PGDATA/PG_VERSION" ]; then
+    mkdir -p "$PGDATA"
+    chown postgres:postgres "$PGDATA"
+    su postgres -c "initdb -D $PGDATA"
 fi
 
-service postgresql start
+su postgres -c "pg_ctl -D $PGDATA -o '-c listen_addresses=*' -w start"
 
 # ensure postgres is ready
 until pg_isready -U postgres; do


### PR DESCRIPTION
## Summary
- install default postgres packages
- use generic postgres image in docker-compose
- initialize postgres in `/var/lib/postgresql/data`
- document new data path in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685173777cf0833195c9caac1ba36851