### PR TITLE
Fix entrypoint path for postgres

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -7,10 +7,10 @@ PGDATA=/var/lib/postgresql/data
 if [ ! -s "$PGDATA/PG_VERSION" ]; then
     mkdir -p "$PGDATA"
     chown postgres:postgres "$PGDATA"
-    su postgres -c "initdb -D $PGDATA"
+    su - postgres -c "initdb -D $PGDATA"
 fi
 
-su postgres -c "pg_ctl -D $PGDATA -o '-c listen_addresses=*' -w start"
+su - postgres -c "pg_ctl -D $PGDATA -o '-c listen_addresses=*' -w start"
 
 # ensure postgres is ready
 until pg_isready -U postgres; do
@@ -19,10 +19,10 @@ until pg_isready -U postgres; do
 done
 
 # set password and create database
-su postgres -c "psql -c \"ALTER USER postgres PASSWORD 'banco@mep';\""
+su - postgres -c "psql -c \"ALTER USER postgres PASSWORD 'banco@mep';\""
 
-su postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='BD_MEP'\" | grep -q 1 || createdb BD_MEP"
+su - postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='BD_MEP'\" | grep -q 1 || createdb BD_MEP"
 
-su postgres -c "psql BD_MEP < /app/scripts/create_tables.sql"
+su - postgres -c "psql BD_MEP < /app/scripts/create_tables.sql"
 
 exec python /app/MEVA/MEVA.py


### PR DESCRIPTION
## Summary
- fix entrypoint to use login shell so postgres PATH is loaded

## Testing
- `python3 -m py_compile` on all Python files

------
https://chatgpt.com/codex/tasks/task_e_6851b92c63088331aa1c41525188eea4