### PR TITLE
Fix entrypoint path for postgres

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
 set -e
 
+# ensure postgres binaries are on PATH
+PG_BIN_DIR=$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | sort -V | tail -n 1)
+if [ -n "$PG_BIN_DIR" ]; then
+    POSTGRES_PATH="$PG_BIN_DIR:$PATH"
+else
+    POSTGRES_PATH="$PATH"
+fi
+
 PGDATA=/var/lib/postgresql/data
 
 # initialize data directory if empty
 if [ ! -s "$PGDATA/PG_VERSION" ]; then
     mkdir -p "$PGDATA"
     chown postgres:postgres "$PGDATA"
-    su postgres -c "initdb -D $PGDATA"
+    su - postgres -c "PATH=$POSTGRES_PATH initdb -D $PGDATA"
 fi
 
-su postgres -c "pg_ctl -D $PGDATA -o '-c listen_addresses=*' -w start"
+su - postgres -c "PATH=$POSTGRES_PATH pg_ctl -D $PGDATA -o '-c listen_addresses=*' -w start"
 
 # ensure postgres is ready
 until pg_isready -U postgres; do
@@ -19,10 +27,10 @@ until pg_isready -U postgres; do
 done
 
 # set password and create database
-su postgres -c "psql -c \"ALTER USER postgres PASSWORD 'banco@mep';\""
+su - postgres -c "PATH=$POSTGRES_PATH psql -c \"ALTER USER postgres PASSWORD 'banco@mep';\""
 
-su postgres -c "psql -tc \"SELECT 1 FROM pg_database WHERE datname='BD_MEP'\" | grep -q 1 || createdb BD_MEP"
+su - postgres -c "PATH=$POSTGRES_PATH psql -tc \"SELECT 1 FROM pg_database WHERE datname='BD_MEP'\" | grep -q 1 || createdb BD_MEP"
 
-su postgres -c "psql BD_MEP < /app/scripts/create_tables.sql"
+su - postgres -c "PATH=$POSTGRES_PATH psql BD_MEP < /app/scripts/create_tables.sql"
 
 exec python /app/MEVA/MEVA.py


### PR DESCRIPTION
## Summary
- fix entrypoint to use explicit PATH for postgres binaries

## Testing
- `python3 -m py_compile` on all Python files

------
https://chatgpt.com/codex/tasks/task_e_6851b92c63088331aa1c41525188eea4