### PR TITLE
Fix database encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ esteja vazio.
 
 O container inicia o PostgreSQL, cria o banco `BD_MEP` com as tabelas definidas em
 `scripts/create_tables.sql` e em seguida executa a aplicação Flask.
+Para evitar problemas de codificacao, o `docker-compose.yml` define a variavel `POSTGRES_INITDB_ARGS` com `--encoding=UTF8`. Assim o cluster do PostgreSQL e inicializado em UTF-8 e aceita corretamente dados com acentuacao.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       POSTGRES_DB: BD_MEP
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: banco@mep
+      # Garante que o cluster inicial do PostgreSQL use UTF-8
+      POSTGRES_INITDB_ARGS: --encoding=UTF8 --locale=en_US.UTF-8
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
## Summary
- initialize the postgres cluster with UTF-8 encoding
- document UTF-8 database initialization in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851be2af82c83319bbdc189f3f4912d