### PR TITLE
Fix Unicode handling

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -39,6 +39,8 @@ import database
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
 
 app = Flask(__name__)
+# Ensure JSON responses handle Unicode characters correctly
+app.config["JSON_AS_ASCII"] = False
 
 def measure_sensor_pair(sensor_pair):
     machine_id = sensor_pair[2]
@@ -125,7 +127,8 @@ def get_db_conn():
         host=config.DB_HOST,
         dbname=config.DB_NAME,
         user=config.DB_USER,
-        password=config.DB_PASS
+        password=config.DB_PASS,
+        options='-c client_encoding=UTF8'
     )
     return conn
 

--- a/MEVA/database.py
+++ b/MEVA/database.py
@@ -6,6 +6,7 @@ def connect():
         host=config.DB_HOST,
         database=config.DB_NAME,
         user=config.DB_USER,
-        password=config.DB_PASS
+        password=config.DB_PASS,
+        options='-c client_encoding=UTF8'
     )
     return conn

--- a/MEVA/limits.py
+++ b/MEVA/limits.py
@@ -4,11 +4,11 @@ LIMITS_FILE = 'limits.json'
 
 def load_limits():
     try:
-        with open(LIMITS_FILE, 'r') as file:
+        with open(LIMITS_FILE, 'r', encoding='utf-8') as file:
             return json.load(file)
     except FileNotFoundError:
         return {}
 
 def save_limits(limits):
-    with open(LIMITS_FILE, 'w') as file:
-        json.dump(limits, file)
+    with open(LIMITS_FILE, 'w', encoding='utf-8') as file:
+        json.dump(limits, file, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- allow UTF-8 characters in JSON responses
- set UTF-8 encoding for database connections
- read/write limits.json using UTF-8

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851c1b834448331b275e87ce96b42ac