### PR TITLE
Fix DB connection and UTF-8

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -121,13 +121,8 @@ def start_measurement_threads():
 
 # Conexão com o banco de dados
 def get_db_conn():
-    conn = psycopg2.connect(
-        host=config.DB_HOST,
-        dbname=config.DB_NAME,
-        user=config.DB_USER,
-        password=config.DB_PASS
-    )
-    return conn
+    """Wrapper around :func:`database.connect` for backward compatibility."""
+    return database.connect()
 
 def get_maquinas():
     conn = get_db_conn()

--- a/MEVA/config.py
+++ b/MEVA/config.py
@@ -1,6 +1,8 @@
 # config.py
-DB_HOST = "localhost"
-DB_NAME = "BD_MEP"
-DB_USER = "postgres"
-DB_PASS = "banco@mep"
-SENSOR_PORT = 8899
+import os
+
+DB_HOST = os.getenv("DB_HOST", "localhost")
+DB_NAME = os.getenv("DB_NAME", "BD_MEP")
+DB_USER = os.getenv("DB_USER", "postgres")
+DB_PASS = os.getenv("DB_PASS", "banco@mep")
+SENSOR_PORT = int(os.getenv("SENSOR_PORT", "8899"))

--- a/MEVA/database.py
+++ b/MEVA/database.py
@@ -1,11 +1,37 @@
+import os
+from urllib.parse import urlparse, unquote
 import psycopg2
 import config
 
 def connect():
-    conn = psycopg2.connect(
-        host=config.DB_HOST,
-        database=config.DB_NAME,
-        user=config.DB_USER,
-        password=config.DB_PASS
-    )
+    """Create a new database connection.
+
+    The function first checks for the ``DATABASE_URL`` environment variable. If
+    present, it is parsed and used to establish the connection. This allows the
+    application to work both when running standalone (using the values from
+    ``config.py``) and inside Docker where a connection URL is provided via the
+    environment.  The connection client encoding is forced to UTF-8 so the
+    database correctly handles special characters such as ``ç`` or ``~``.
+    """
+
+    db_url = os.getenv("DATABASE_URL")
+    if db_url:
+        parsed = urlparse(db_url)
+        conn = psycopg2.connect(
+            host=parsed.hostname,
+            port=parsed.port,
+            dbname=parsed.path.lstrip("/"),
+            user=parsed.username,
+            password=unquote(parsed.password) if parsed.password else None,
+        )
+    else:
+        conn = psycopg2.connect(
+            host=config.DB_HOST,
+            dbname=config.DB_NAME,
+            user=config.DB_USER,
+            password=config.DB_PASS,
+        )
+
+    # Ensure UTF-8 client encoding so special characters are stored correctly
+    conn.set_client_encoding("UTF8")
     return conn


### PR DESCRIPTION
## Summary
- use DATABASE_URL if available and set UTF-8 encoding
- read DB settings from environment
- update Flask code to use new database.connect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c5a1d3d48331a8e4eec3484b4004