### PR TITLE
Fix DATABASE_URL encoding in Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgres://postgres:banco@mep@db:5432/BD_MEP
+      DATABASE_URL: postgres://postgres:banco%40mep@db:5432/BD_MEP
     networks:
       - meva-net
 


### PR DESCRIPTION
## Summary
- encode the `@` sign in the Postgres DATABASE_URL

## Testing
- `python -m py_compile $(find MEVA -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6851ccabf0a083319d3ddc0d5c1c2345