### PR TITLE
Add mobile monitor view

### DIFF
--- a/MEVA/queries.py
+++ b/MEVA/queries.py
@@ -36,6 +36,22 @@ def get_last_60_minutes_measurements(machine_id, position_id):
     conn.close()
     return result
 
+def get_last_minutes_measurements(machine_id, position_id, minutes):
+    conn = connect()
+    cur = conn.cursor()
+    query = (
+        "SELECT ID, date_trunc('second', Data_Hora), Maquina_ID, Posicao_Leitura_ID, "
+        "Valor_Medicao_Superior, Valor_Medicao_Inferior "
+        "FROM Medicoes "
+        "WHERE Maquina_ID = %s AND Posicao_Leitura_ID = %s AND "
+        f"Data_Hora > NOW() - INTERVAL '{minutes} minutes' "
+        "ORDER BY Data_Hora ASC;"
+    )
+    cur.execute(query, (machine_id, position_id))
+    result = cur.fetchall()
+    conn.close()
+    return result
+
 
 def get_calibrations(machine_id, position_id):
     conn = connect()

--- a/MEVA/static/script.js
+++ b/MEVA/static/script.js
@@ -61,3 +61,58 @@ function createChart(elementId, labels, upperLimit, lowerLimit, graphData) {
         }
     });
 }
+
+function createMiniChart(elementId, labels, upperLimit, lowerLimit, values) {
+    var ctx = document.getElementById(elementId).getContext('2d');
+    var chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [
+                {
+                    label: 'Espessura',
+                    borderColor: '#059bff',
+                    data: values,
+                    spanGaps: true,
+                    fill: false,
+                    cubicInterpolationMode: 'monotone',
+                    tension: 0.1,
+                    pointRadius: 0
+                },
+                {
+                    label: 'Limite Superior',
+                    data: Array(labels.length).fill(upperLimit),
+                    borderColor: 'red',
+                    borderWidth: 1,
+                    fill: false,
+                    pointRadius: 0
+                },
+                {
+                    label: 'Limite Inferior',
+                    data: Array(labels.length).fill(lowerLimit),
+                    borderColor: 'red',
+                    borderWidth: 1,
+                    fill: false,
+                    pointRadius: 0
+                }
+            ]
+        },
+        options: {
+            animation: false,
+            scales: {
+                y: {
+                    min: (lowerLimit - 0.5),
+                    max: (upperLimit + 0.5)
+                },
+                x: {
+                    ticks: {
+                        autoSkip: true,
+                        maxTicksLimit: 10,
+                        maxRotation: 0,
+                        minRotation: 0
+                    }
+                }
+            }
+        }
+    });
+}

--- a/MEVA/static/style.css
+++ b/MEVA/static/style.css
@@ -241,3 +241,27 @@ a {
 .back-button:hover {
     background-color: #0056b3;
 }
+
+.mobile-card {
+    background-color: #007bff;
+    color: white;
+    margin-bottom: 10px;
+    border-radius: 5px;
+}
+
+.mobile-card.out-of-limits {
+    background-color: #ff4069;
+}
+
+.mobile-card .card-header {
+    display: flex;
+    justify-content: space-between;
+    padding: 10px;
+    cursor: pointer;
+}
+
+.mobile-card .card-body {
+    background-color: white;
+    color: black;
+    padding: 10px;
+}

--- a/MEVA/templates/mobile.html
+++ b/MEVA/templates/mobile.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <script src="{{ url_for('static', filename='chart.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+    <title>Monitoramento Mobile</title>
+</head>
+<body>
+    <a href="{{ url_for('homepage') }}" class="back-button">Voltar</a>
+    {% for machine in machines %}
+    <div class="mobile-card {% if machine.out_of_limits %}out-of-limits{% endif %}">
+        <div class="card-header" onclick="toggleCard('card-{{ loop.index }}')">
+            <span><strong>{{ machine.name }}</strong></span>
+            <span>{{ machine.current|round(2) if machine.current is not none else 'N/A' }}</span>
+        </div>
+        <div class="card-body" id="card-{{ loop.index }}" style="display: none;">
+            <div class="graph-section">
+                <canvas id="chart-{{ loop.index }}" height="100"></canvas>
+            </div>
+            <div class="stats-section">
+                <h4>Médias</h4>
+                <p>Últimos 15 min: {{ machine.avg15|round(2) if machine.avg15 is not none else 'N/A' }}</p>
+                <p>Últimos 30 min: {{ machine.avg30|round(2) if machine.avg30 is not none else 'N/A' }}</p>
+                <p>Últimos 60 min: {{ machine.avg60|round(2) if machine.avg60 is not none else 'N/A' }}</p>
+                <p>Últimas 3 horas: {{ machine.avg3h|round(2) if machine.avg3h is not none else 'N/A' }}</p>
+            </div>
+            <div class="stats-section">
+                <h4>Qualidade</h4>
+                <p>Inconformidade limite sup.: {{ machine.sup }}</p>
+                <p>Inconformidade limite inf.: {{ machine.inf }}</p>
+                <p>% inconformidade (1h): {{ machine.perc|round(2) }}%</p>
+            </div>
+            <div class="stats-section">
+                <h4>Estatísticas</h4>
+                <p>Desvio padrão: {{ machine.std_dev|round(2) if machine.std_dev is not none else 'N/A' }}</p>
+                <p>Espessura máxima: {{ machine.max|round(2) if machine.max is not none else 'N/A' }}</p>
+                <p>Espessura mínima: {{ machine.min|round(2) if machine.min is not none else 'N/A' }}</p>
+                <p>Frequência média (medições/min): {{ machine.freq|round(2) }}</p>
+            </div>
+        </div>
+    </div>
+    <script>
+        createMiniChart('chart-{{ loop.index }}',
+            {{ machine.labels|tojson }},
+            {{ machine.limits.upper }},
+            {{ machine.limits.lower }},
+            {{ machine.values|tojson }});
+    </script>
+    {% endfor %}
+    <script>
+    function toggleCard(id) {
+        var el = document.getElementById(id);
+        if (el.style.display === 'none') {
+            el.style.display = 'block';
+        } else {
+            el.style.display = 'none';
+        }
+    }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement endpoint `/mobile` for mobile device monitoring
- compute averages, deviations, and quality metrics
- provide new mini chart function and toggle card styles
- create `mobile.html` template for mobile-friendly monitoring

## Testing
- `python -m py_compile MEVA/MEVA.py MEVA/queries.py`

------
https://chatgpt.com/codex/tasks/task_e_685304b56a988331b1b2df2e04e917cb