### PR TITLE
Fix static asset URLs for monitoring graphs

### DIFF
--- a/MEVA/templates/index_view.html
+++ b/MEVA/templates/index_view.html
@@ -5,10 +5,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="refresh" content="15">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <title>Monitoramento</title>
-    <script src="/static/chart.min.js"></script>
-    <script src="/static/script.js"></script> <!-- Inclua o arquivo script.js -->
+    <script src="{{ url_for('static', filename='chart.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
 </head>
 <body>
     <a href="{{ url_for('homepage') }}" class="back-button">Voltar</a>

--- a/MEVA/templates/index_view_h.html
+++ b/MEVA/templates/index_view_h.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <title>Histórico</title>
-    <script src="/static/chart.min.js"></script>
-    <script src="/static/script.js"></script> <!-- Inclua o arquivo script.js -->
+    <script src="{{ url_for('static', filename='chart.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
 </head>
 <form action="/view_h" method="get">
     <label for="datetime">Selecione a data e hora:</label>


### PR DESCRIPTION
## Summary
- use `url_for` for static asset paths in graph templates

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685320361d3083318b4931853c8a829e