### PR TITLE
Use config sensor port

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -56,7 +56,7 @@ def measure_sensor_pair(sensor_pair):
 
         # Função auxiliar para obter a distância
         def fetch_distance(ip):
-            return get_distance(ip, 8899)
+            return get_distance(ip, config.SENSOR_PORT)
 
         # Use ThreadPoolExecutor para executar as chamadas de forma paralela
         with concurrent.futures.ThreadPoolExecutor() as executor:
@@ -324,7 +324,7 @@ def status():
     sensors = get_sensors()
     for sensor in sensors:
         sensor_ip = sensor[1]
-        distance = fast_get_distance(sensor_ip,8899)
+        distance = fast_get_distance(sensor_ip, config.SENSOR_PORT)
         status = "connected" if distance is not None else "disconnected"
         update_sensor_status(sensor[0], status)
     
@@ -673,7 +673,7 @@ def sensor_reading(sensor_id):
     value = None
     if sensor:
         ip = sensor[1]
-        value = fast_get_distance(ip, 8899)
+        value = fast_get_distance(ip, config.SENSOR_PORT)
     return jsonify({'value': value})
 
 

--- a/MEVA/fake_sensor.py
+++ b/MEVA/fake_sensor.py
@@ -1,6 +1,7 @@
 from pymodbus.server.sync import StartTcpServer
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
+import config
 
 # Definindo o valor que será retornado (50.0mm)
 value_to_return_mm = 50.0
@@ -21,7 +22,7 @@ block = ModbusSequentialDataBlock(0x0000, [register1, register2] + [0] * 100)
 store = ModbusSlaveContext(ir=block)
 context = ModbusServerContext(slaves=store, single=True)
 # Porta para o servidor escutar
-port = 8899
+port = config.SENSOR_PORT
 
 # Iniciando o servidor na porta especificada
 StartTcpServer(context, address=("0.0.0.0", port))

--- a/MEVA/temp_get_distance_run.py
+++ b/MEVA/temp_get_distance_run.py
@@ -1,4 +1,5 @@
 from pymodbus.client.sync import ModbusTcpClient
+import config
 
 def get_distance(IP_ADDRESS, PORT):
     # Conectando ao servidor MODBUS
@@ -61,7 +62,7 @@ def get_distance(IP_ADDRESS, PORT):
 
 # Exemplo de uso:
 IP_ADDRESS = '192.168.1.182'
-PORT = 8899
+PORT = config.SENSOR_PORT
 distance_mm = get_distance(IP_ADDRESS, PORT)
 if distance_mm is not None:
     print("Distância:", distance_mm, "mm")


### PR DESCRIPTION
## Summary
- reference `config.SENSOR_PORT` instead of hard-coded `8899`
- update sample scripts to import and use `config.SENSOR_PORT`

## Testing
- `python -m py_compile MEVA/MEVA.py MEVA/fake_sensor.py MEVA/temp_get_distance_run.py`

------
https://chatgpt.com/codex/tasks/task_e_6853236d693883318e22baa17a9eb4ed