### PR TITLE
Fix mobile view latest measurement

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -548,6 +548,21 @@ def mobile_view():
                     latest_time = m_time
                     latest_val = thickness
 
+            if not measurements:
+                last = queries.get_last_measurement(machine_id, position_id)
+                if last:
+                    m_time = last[1]
+                    calibration_value = 0
+                    for cal in calibrations:
+                        if cal[0] <= m_time:
+                            calibration_value = cal[1]
+                        else:
+                            break
+                    thickness = calibration_value - last[4] - last[5]
+                    if latest_time is None or m_time > latest_time:
+                        latest_time = m_time
+                        latest_val = thickness
+
         times_15 = sorted([t for t in thickness_per_timestamp if now - t <= timedelta(minutes=15)])
         labels = [t.strftime('%H:%M') for t in times_15]
         values = [sum(thickness_per_timestamp[t]) / len(thickness_per_timestamp[t]) for t in times_15]

--- a/MEVA/queries.py
+++ b/MEVA/queries.py
@@ -52,6 +52,22 @@ def get_last_minutes_measurements(machine_id, position_id, minutes):
     conn.close()
     return result
 
+def get_last_measurement(machine_id, position_id):
+    """Return the most recent measurement for a given machine and position."""
+    conn = connect()
+    cur = conn.cursor()
+    query = (
+        "SELECT ID, date_trunc('second', Data_Hora), Maquina_ID, Posicao_Leitura_ID, "
+        "Valor_Medicao_Superior, Valor_Medicao_Inferior "
+        "FROM Medicoes "
+        "WHERE Maquina_ID = %s AND Posicao_Leitura_ID = %s "
+        "ORDER BY Data_Hora DESC LIMIT 1;"
+    )
+    cur.execute(query, (machine_id, position_id))
+    result = cur.fetchone()
+    conn.close()
+    return result
+
 
 def get_calibrations(machine_id, position_id):
     conn = connect()


### PR DESCRIPTION
## Summary
- show the most recent measurement on the mobile page even when none exist within the last 3h
- add helper to retrieve the last measurement

## Testing
- `python -m py_compile MEVA/queries.py MEVA/MEVA.py`

------
https://chatgpt.com/codex/tasks/task_e_6853262549e0833183b5d9cea7188eb8