### PR TITLE
Fix measurement loop timer

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -27,6 +27,8 @@ def measure_sensor_pair(sensor_pair):
     superior_distances = []
     inferior_distances = []
 
+    loop_start = time.time()
+
     while True:
         
         superior_ip = sensor_pair[1]


### PR DESCRIPTION
## Summary
- initialize `loop_start` before entering the measurement loop

## Testing
- `python -m py_compile MEVA/MEVA.py`
- `python -m py_compile MEVA/get_distance.py MEVA/fast_get_distance.py MEVA/temp_get_distance_run.py`

------
https://chatgpt.com/codex/tasks/task_e_6859aa8b3450833193a5f156a6348fbf