### PR TITLE
Fix mobile chart visibility

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -47,6 +47,11 @@ def measure_sensor_pair(sensor_pair):
             inferior_distance = inferior_future.result()
 
         logging.info(
+            f"Fetched distances for machine {machine_id}, position {position_id}: "
+            f"sup={superior_distance} inf={inferior_distance}"
+        )
+
+        logging.info(
             f"Distance fetch for machine {machine_id}, position {position_id} took {time.time() - loop_start:.2f}s"
         )
 
@@ -575,6 +580,10 @@ def mobile_view():
         times_15 = sorted([t for t in thickness_per_timestamp if now - t <= timedelta(minutes=15)])
         labels = [t.strftime('%H:%M') for t in times_15]
         values = [sum(thickness_per_timestamp[t]) / len(thickness_per_timestamp[t]) for t in times_15]
+
+        logging.info(
+            f"Mobile view data for machine {machine_id}: labels={labels}, values={values}"
+        )
 
         def avg(lst):
             return sum(lst) / len(lst) if lst else None

--- a/MEVA/static/script.js
+++ b/MEVA/static/script.js
@@ -3,13 +3,24 @@ function createChart(elementId, labels, upperLimit, lowerLimit, graphData) {
     var colors = ['#059bff', '#ff4069', '#ff9020', '#22cfcf'];
     
     var datasets = [];
+    var dataMin = Infinity;
+    var dataMax = -Infinity;
     for (var i = 0; i < graphData.length; i++) {
         var position_data = graphData[i];
         var color = colors[i % colors.length]; // Seleciona a cor com base no índice
+        var values = position_data[1];
+        // Atualiza limites encontrados nos dados
+        for (var j = 0; j < values.length; j++) {
+            var v = values[j];
+            if (v !== null && !isNaN(v)) {
+                dataMin = Math.min(dataMin, v);
+                dataMax = Math.max(dataMax, v);
+            }
+        }
         datasets.push({
             label: position_data[0],
             borderColor: color, // Use a cor selecionada
-            data: position_data[1],
+            data: values,
             spanGaps: true,
             fill: false,
             cubicInterpolationMode: 'monotone',
@@ -36,6 +47,14 @@ function createChart(elementId, labels, upperLimit, lowerLimit, graphData) {
         pointRadius: 0
     });
 
+    // Determina os limites do eixo Y usando os dados quando disponíveis
+    if (dataMin === Infinity) {
+        dataMin = lowerLimit;
+    }
+    if (dataMax === -Infinity) {
+        dataMax = upperLimit;
+    }
+
     var chart = new Chart(ctx, {
         type: 'line',
         data: {
@@ -46,8 +65,8 @@ function createChart(elementId, labels, upperLimit, lowerLimit, graphData) {
             animation: false,
             scales: {
                 y: {
-                    min: (lowerLimit - 0.5),
-                    max: (upperLimit + 0.5)
+                    min: Math.min(lowerLimit - 0.5, dataMin - 0.1),
+                    max: Math.max(upperLimit + 0.5, dataMax + 0.1)
                 },
                 x: {
                     ticks: {
@@ -64,6 +83,24 @@ function createChart(elementId, labels, upperLimit, lowerLimit, graphData) {
 
 function createMiniChart(elementId, labels, upperLimit, lowerLimit, values) {
     var ctx = document.getElementById(elementId).getContext('2d');
+
+    var dataMin = Infinity;
+    var dataMax = -Infinity;
+    for (var i = 0; i < values.length; i++) {
+        var v = values[i];
+        if (v !== null && !isNaN(v)) {
+            dataMin = Math.min(dataMin, v);
+            dataMax = Math.max(dataMax, v);
+        }
+    }
+
+    if (dataMin === Infinity) {
+        dataMin = lowerLimit;
+    }
+    if (dataMax === -Infinity) {
+        dataMax = upperLimit;
+    }
+
     var chart = new Chart(ctx, {
         type: 'line',
         data: {
@@ -101,8 +138,8 @@ function createMiniChart(elementId, labels, upperLimit, lowerLimit, values) {
             animation: false,
             scales: {
                 y: {
-                    min: (lowerLimit - 0.5),
-                    max: (upperLimit + 0.5)
+                    min: Math.min(lowerLimit - 0.5, dataMin - 0.1),
+                    max: Math.max(upperLimit + 0.5, dataMax + 0.1)
                 },
                 x: {
                     ticks: {

--- a/MEVA/templates/mobile.html
+++ b/MEVA/templates/mobile.html
@@ -18,7 +18,7 @@
         </div>
         <div class="card-body" id="card-{{ loop.index }}" style="display: none;">
             <div class="graph-section">
-                <canvas id="chart-{{ loop.index }}" height="100"></canvas>
+                <canvas id="chart-{{ loop.index }}" width="400" height="100"></canvas>
             </div>
             <div class="stats-section">
                 <h4>Médias</h4>


### PR DESCRIPTION
## Summary
- specify canvas dimensions for mobile graphs so Chart.js renders while collapsed
- scale chart axes based on data range to show points outside preset limits

## Testing
- `python -m py_compile MEVA/MEVA.py`


------
https://chatgpt.com/codex/tasks/task_e_68599e4b24148331980dc827f803716b