### PR TITLE
Atualiza timeout e intervalo de leitura do sensor

### DIFF
--- a/MEVA/fast_get_distance.py
+++ b/MEVA/fast_get_distance.py
@@ -3,7 +3,7 @@ import logging
 
 def fast_get_distance(IP_ADDRESS, PORT):
     # Conectando ao servidor MODBUS
-    client = ModbusTcpClient(IP_ADDRESS, port=PORT)
+    client = ModbusTcpClient(IP_ADDRESS, port=PORT, timeout=1)
 
     # Se a conexão for bem-sucedida
     if client.connect():

--- a/MEVA/get_distance.py
+++ b/MEVA/get_distance.py
@@ -7,7 +7,7 @@ import logging
 def get_distance(IP_ADDRESS, PORT):
     start_time = time.time()
     # Conectando ao servidor MODBUS
-    client = ModbusTcpClient(IP_ADDRESS, port=PORT)
+    client = ModbusTcpClient(IP_ADDRESS, port=PORT, timeout=1)
 
     # Lista para armazenar as distâncias obtidas
     distances = []
@@ -18,7 +18,7 @@ def get_distance(IP_ADDRESS, PORT):
         if client.connect():
             errors = 0
             for _ in range(26):
-                time.sleep(0.02)
+                time.sleep(0.03)
                 # Enviando o comando
                 response = client.read_input_registers(address=0x0000, count=2, unit=0x01)
 

--- a/MEVA/temp_get_distance_run.py
+++ b/MEVA/temp_get_distance_run.py
@@ -3,7 +3,7 @@ import logging
 
 def get_distance(IP_ADDRESS, PORT):
     # Conectando ao servidor MODBUS
-    client = ModbusTcpClient(IP_ADDRESS, port=PORT)
+    client = ModbusTcpClient(IP_ADDRESS, port=PORT, timeout=1)
 
     # Lista para armazenar as distâncias obtidas
     distances = []


### PR DESCRIPTION
## Summary
- ajusta o tempo entre leituras para 0.03s
- define timeout de 1s ao conectar via ModbusTcpClient

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b607374c8331b9aab7d7375fa46b