### PR TITLE
Add history navigation buttons

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -408,6 +408,8 @@ def view_h():
         # If no date was provided, default to the last hour
         start_time = datetime.utcnow() - timedelta(hours=1)
 
+    selected_datetime = (start_time + LOCAL_TIME_OFFSET).strftime("%Y-%m-%dT%H:%M")
+
     end_time = start_time + timedelta(minutes=60)
 
     for machine in machines:
@@ -450,7 +452,7 @@ def view_h():
             'limits': limit_data.get(str(machine_id), {'lower': 1, 'upper': 4}),
         })
 
-    return render_template('index_view_h.html', machines=machine_data)
+    return render_template('index_view_h.html', machines=machine_data, selected_datetime=selected_datetime)
 
 
 @app.route('/view')

--- a/MEVA/static/script.js
+++ b/MEVA/static/script.js
@@ -153,3 +153,21 @@ function createMiniChart(elementId, labels, upperLimit, lowerLimit, values) {
         }
     });
 }
+
+function formatLocalDateTime(dt) {
+    var year = dt.getFullYear();
+    var month = String(dt.getMonth() + 1).padStart(2, '0');
+    var day = String(dt.getDate()).padStart(2, '0');
+    var hour = String(dt.getHours()).padStart(2, '0');
+    var minute = String(dt.getMinutes()).padStart(2, '0');
+    return year + '-' + month + '-' + day + 'T' + hour + ':' + minute;
+}
+
+function moveHistory(minutes) {
+    var input = document.getElementById('datetime');
+    var current = input.value;
+    var dt = current ? new Date(current) : new Date();
+    dt.setMinutes(dt.getMinutes() + minutes);
+    input.value = formatLocalDateTime(dt);
+    document.getElementById('history-form').submit();
+}

--- a/MEVA/static/style.css
+++ b/MEVA/static/style.css
@@ -108,6 +108,16 @@ input[type="submit"]:hover {
     display: flex;
     justify-content: space-around;
 }
+.button-group button {
+    background-color: #007bff;
+    color: white;
+    border: none;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+.button-group button:hover {
+    background-color: #0056b3;
+}
 
 .limit-button {
     padding: 10px;

--- a/MEVA/templates/index_view_h.html
+++ b/MEVA/templates/index_view_h.html
@@ -9,10 +9,16 @@
     <script src="{{ url_for('static', filename='chart.min.js') }}"></script>
     <script src="{{ url_for('static', filename='script.js') }}"></script>
 </head>
-<form action="/view_h" method="get">
+<form action="/view_h" method="get" id="history-form">
     <label for="datetime">Selecione a data e hora:</label>
-    <input type="datetime-local" id="datetime" name="datetime">
+    <input type="datetime-local" id="datetime" name="datetime" value="{{ selected_datetime }}">
     <input type="submit" value="Ver histórico">
+    <div class="button-group">
+        <button type="button" onclick="moveHistory(-60)">-60 min</button>
+        <button type="button" onclick="moveHistory(-30)">-30 min</button>
+        <button type="button" onclick="moveHistory(30)">+30 min</button>
+        <button type="button" onclick="moveHistory(60)">+60 min</button>
+    </div>
 </form>
 <body>
     <a href="{{ url_for('homepage') }}" class="back-button">Voltar</a>


### PR DESCRIPTION
## Summary
- show selected datetime in history view
- add forward/back buttons to move 30 or 60 minutes in history view
- style history navigation buttons and implement moveHistory JS function

## Testing
- `python -m py_compile $(find MEVA -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ab4738cc48331a52588e765da8675