### PR TITLE
Add editable limits screen

### DIFF
--- a/MEVA/limits.py
+++ b/MEVA/limits.py
@@ -2,6 +2,9 @@ import json
 
 LIMITS_FILE = 'limits.json'
 
+DEFAULT_UPPER = 2.2
+DEFAULT_LOWER = 1.8
+
 def load_limits():
     try:
         with open(LIMITS_FILE, 'r') as file:

--- a/MEVA/templates/limits.html
+++ b/MEVA/templates/limits.html
@@ -13,12 +13,13 @@
         {% for machine_name, lower_limit, upper_limit, machine_id in machine_limits %}
         <div class="machine-block">
             <h3>{{ machine_name }}</h3>
-            <p>Limite inferior: {{ lower_limit }}</p>
-            <p>Limite superior: {{ upper_limit }}</p>
-            <div class="button-group">
-                <a href="{{ url_for('set_limits', machine_id=machine_id, limit=2) }}" class="limit-button">2mm</a>
-                <a href="{{ url_for('set_limits', machine_id=machine_id, limit=3) }}" class="limit-button">3mm</a>
-            </div>
+            <form method="post" action="{{ url_for('set_limits', machine_id=machine_id) }}">
+                <label for="lower_{{ machine_id }}">Limite inferior:</label>
+                <input type="number" step="0.1" name="lower_limit" id="lower_{{ machine_id }}" value="{{ lower_limit }}">
+                <label for="upper_{{ machine_id }}">Limite superior:</label>
+                <input type="number" step="0.1" name="upper_limit" id="upper_{{ machine_id }}" value="{{ upper_limit }}">
+                <input type="submit" value="Salvar" class="limit-button">
+            </form>
         </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- allow editing lower and upper limits per machine
- persist custom limits
- default to 2.2mm upper and 1.8mm lower if no values saved

## Testing
- `python -m py_compile MEVA/MEVA.py MEVA/limits.py`


------
https://chatgpt.com/codex/tasks/task_e_685ab5357478833198efb654383a9674