### PR TITLE
Add interval buttons for history view

### DIFF
--- a/MEVA/MEVA.py
+++ b/MEVA/MEVA.py
@@ -399,18 +399,20 @@ def view_h():
     limit_data = limits.load_limits()
 
     machine_data = []
-    
+
+    hours = int(request.args.get('hours', 1))
+
     datetime_str = request.args.get('datetime')
     if datetime_str:
         # O horário informado é considerado local (UTC-3). Converta para UTC para consultar o banco.
         start_time = datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M") - LOCAL_TIME_OFFSET
     else:
-        # If no date was provided, default to the last hour
-        start_time = datetime.utcnow() - timedelta(hours=1)
+        # If no date was provided, default to the last ``hours`` hours
+        start_time = datetime.utcnow() - timedelta(hours=hours)
 
     selected_datetime = (start_time + LOCAL_TIME_OFFSET).strftime("%Y-%m-%dT%H:%M")
 
-    end_time = start_time + timedelta(minutes=60)
+    end_time = start_time + timedelta(hours=hours)
 
     for machine in machines:
         machine_id = machine[0]
@@ -455,7 +457,12 @@ def view_h():
             ),
         })
 
-    return render_template('index_view_h.html', machines=machine_data, selected_datetime=selected_datetime)
+    return render_template(
+        'index_view_h.html',
+        machines=machine_data,
+        selected_datetime=selected_datetime,
+        selected_hours=hours,
+    )
 
 
 @app.route('/view')

--- a/MEVA/static/script.js
+++ b/MEVA/static/script.js
@@ -175,3 +175,11 @@ function moveHistory(minutes) {
     input.value = formatLocalDateTime(dt);
     document.getElementById('history-form').submit();
 }
+
+function setRange(hours) {
+    var dt = new Date();
+    dt.setHours(dt.getHours() - hours);
+    document.getElementById('datetime').value = formatLocalDateTime(dt);
+    document.getElementById('hours').value = hours;
+    document.getElementById('history-form').submit();
+}

--- a/MEVA/templates/index_view_h.html
+++ b/MEVA/templates/index_view_h.html
@@ -12,12 +12,18 @@
 <form action="/view_h" method="get" id="history-form">
     <label for="datetime">Selecione a data e hora:</label>
     <input type="datetime-local" id="datetime" name="datetime" value="{{ selected_datetime }}">
+    <input type="hidden" id="hours" name="hours" value="{{ selected_hours }}">
     <input type="submit" value="Ver histórico">
     <div class="button-group">
         <button type="button" onclick="moveHistory(-60)">-60 min</button>
         <button type="button" onclick="moveHistory(-30)">-30 min</button>
         <button type="button" onclick="moveHistory(30)">+30 min</button>
         <button type="button" onclick="moveHistory(60)">+60 min</button>
+    </div>
+    <div class="button-group">
+        <button type="button" onclick="setRange(12)">12h</button>
+        <button type="button" onclick="setRange(24)">24h</button>
+        <button type="button" onclick="setRange(48)">48h</button>
     </div>
 </form>
 <body>


### PR DESCRIPTION
## Summary
- Allow changing history graph range via new `12h`, `24h`, and `48h` buttons
- Handle configurable hour range in `/view_h` endpoint
- Add JavaScript helper to update range and refresh data

## Testing
- `python -m py_compile MEVA/MEVA.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892434080b08331ab3c596088c0f033